### PR TITLE
Ch05: Fix error "plot.new has not been called yet" in rendering

### DIFF
--- a/ch05-basic-stats/ch05-stats.qmd
+++ b/ch05-basic-stats/ch05-stats.qmd
@@ -350,9 +350,7 @@ report(fit)
 Draw the quantiles of the residuals and the theoretical quantiles
 ```{r}
 qqnorm(resid(fit))
-```
-Add a line through the theoretical quantiles
-```{r}
+# Add a line through the theoretical quantiles
 qqline(resid(fit))
 ```
 


### PR DESCRIPTION
This pull request fixes an error that occurs when rendering a QMD file. The error message is:

```
processing file: ch05-stats.qmd
  |............................................       |  87% [unnamed-chunk-37]


Quitting from lines 356-357 [unnamed-chunk-37] (ch05-stats.qmd)
Error in `int_abline()`:
! plot.new has not been called yet
Backtrace:
 1. stats::qqline(resid(fit))
 2. graphics::abline(int, slope, ...)
 3. graphics (local) int_abline(a = a, b = b, h = h, v = v, untf = untf, ...)
                                                                                                             
Execution halted
```

This error occurs because the int_abline() function is called before the plot.new() function. The plot.new() function is required to initialize the plotting device.