### PR TITLE
Ch06: Add option to set CRAN repository URL before installing ggplot2

### DIFF
--- a/ch06-data-visualization/ch06-visualization.qmd
+++ b/ch06-data-visualization/ch06-visualization.qmd
@@ -20,6 +20,7 @@ format:
 Installing the `ggplot2` library. 
 
 ```{r, message = FALSE, error = FALSE, warning = FALSE, include = FALSE}
+options(repos = c(CRAN = "https://cloud.r-project.org/"))
 install.packages("ggplot2")
 ```
 


### PR DESCRIPTION
This pull request fixes an error that occurs when rendering the ch06-visualization.qmd file. The error message is:

```
Quitting from lines 23-24 [unnamed-chunk-1] (ch06-visualization.qmd) Error in contrib.url(): ! trying to use CRAN without setting a mirror Backtrace:

utils::install.packages("ggplot2")
utils::contrib.url(repos, "source")
Execution halted
```

This error occurs because the ggplot2 package is not installed and the CRAN mirror is not set. The contrib.url() function is used to retrieve the package repository URL from CRAN, but it requires a mirror to be set.