### PR TITLE
Ch07: Create directory for saving preprocessed data

### DIFF
--- a/ch07-prediction/ch07-prediction.qmd
+++ b/ch07-prediction/ch07-prediction.qmd
@@ -140,6 +140,7 @@ events |>
 
 Store the processed and prepared events data
 ```{r}
+dir.create("preprocessed_data", showWarnings = FALSE)
 saveRDS(events, "preprocessed_data/events.RData")
 ```
 


### PR DESCRIPTION
This pull request fixes an error that occurs when rendering the ch07-prediction.qmd file. The error message is:

```
Quitting from lines 143-144 [unnamed-chunk-18] (ch07-prediction.qmd) Error in gzfile(): ! cannot open the connection Backtrace:

base::saveRDS(events, "preprocessed_data/events.RData")
base::gzfile(file, mode)
Execution halted
```

This error occurs because the preprocessed_data directory does not exist, and the saveRDS() function is unable to create it.
This change should fix the error and allow the ch07-prediction.qmd file to render without errors.