### PR TITLE
Ch10: Fix typo in fig.align parameter value

### DIFF
--- a/ch10-sequence-analysis/ch10-seq.qmd
+++ b/ch10-sequence-analysis/ch10-seq.qmd
@@ -170,7 +170,7 @@ seq_heatmap(Seqobject, clusters_sessionsh)
 ```
 
 Sequence distribution plot for the k=3 cluster solution
-```{r, message=F, fig.align='center",fig.width=7,fig.height=4, dev="png"}
+```{r, message=F, fig.align='center',fig.width=7,fig.height=4, dev="png"}
 Cuts <- cutree(clusters_sessionsh, k = 3)
 Groups <- factor(Cuts, labels = paste("Cluster", 1:3))
 seqplot(Seqobject, type = "d", group = Groups, cex.legend = 0.8, ncol = 2, 


### PR DESCRIPTION
Description:

 - Replaced double quotes with single quotes in the code.
 - Rendering the code with double quotes before the replacement resulted in the following error:
 
Error Message:

```
 : :1:29: unexpected INCOMPLETE_STRING 1: alist( message=F, fig.align='center",fig.width=7,fig.height=4, dev="png" ) ^ Calls: .main ... parse_params -> withCallingHandlers -> eval -> parse_only -> parse Execution halted
```